### PR TITLE
fix(DOD-360): Security patch

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -18,12 +18,12 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'io.hypersistence:hypersistence-utils-hibernate-60:3.3.2'
+    implementation 'io.hypersistence:hypersistence-utils-hibernate-60:3.5.3'
 
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 //    implementation 'org.keycloak:keycloak-policy-enforcer:22.0.1'
-    implementation 'org.keycloak:keycloak-core:22.0.1'
+    implementation 'org.keycloak:keycloak-core:22.0.3'
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
@@ -37,7 +37,7 @@ dependencies {
     implementation 'com.google.guava:guava:31.1-jre'
     implementation 'org.springframework.boot:spring-boot-starter-hateoas'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springframework.retry:spring-retry:2.0.2'
+    implementation 'org.springframework.retry:spring-retry:2.0.3'
     implementation 'ch.qos.logback:logback-classic:1.4.11'
 
     compileOnly 'org.projectlombok:lombok'
@@ -59,8 +59,8 @@ dependencies {
     testImplementation "org.testcontainers:testcontainers:${testcontainersVersion}"
     testImplementation "org.testcontainers:junit-jupiter:${testcontainersVersion}"
 
-    testImplementation "org.keycloak:keycloak-test-helper:22.0.1"
-    testImplementation "org.keycloak:keycloak-admin-client:22.0.1"
+    testImplementation "org.keycloak:keycloak-test-helper:22.0.3"
+    testImplementation "org.keycloak:keycloak-admin-client:22.0.3"
     testImplementation "org.springframework.security:spring-security-test"
 
 }

--- a/selenium-tests/build.gradle
+++ b/selenium-tests/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     testImplementation 'org.seleniumhq.selenium:selenium-java:4.12.1'
     testImplementation 'org.seleniumhq.selenium:selenium-grid:4.12.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
-    testImplementation 'commons-io:commons-io:2.11.0'
+    testImplementation 'commons-io:commons-io:2.13.0'
 }
 
 test {


### PR DESCRIPTION
Updating these dependencies:
- spring-retry 2.0.2 -> 2.0.3
- keycloak-test-helper 22.0.1 -> 22.0.3
- keycloak-core 22.0.1 -> 22.0.3
- commons-io 2.11.0 -> 2.13.0
- hypersistence-utils-hibernate-60 3.3.2 -> 3.5.3