### PR TITLE
fix(DOD-371): Security Patch

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 
     implementation 'mysql:mysql-connector-java:8.0.32'
     implementation 'org.modelmapper:modelmapper:3.1.1'
-    implementation 'com.google.guava:guava:31.1-jre'
+    implementation 'com.google.guava:guava:32.1.2-jre'
     implementation 'org.springframework.boot:spring-boot-starter-hateoas'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.retry:spring-retry:2.0.3'

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 plugins {
 	//https://docs.spring.io/spring-boot/docs/current/reference/html/getting-started.html
-	id 'org.springframework.boot' version '3.0.5' apply false
+	id 'org.springframework.boot' version '3.1.4' apply false
 	id 'jacoco'
 	//https://docs.sonarqube.org/latest/analysis/scan/sonarscanner-for-gradle/
 	id 'org.sonarqube' version '4.3.1.3277'
 	//https://plugins.gradle.org/plugin/io.spring.dependency-management
-	id 'io.spring.dependency-management' version '1.1.0' apply false
+	id 'io.spring.dependency-management' version '1.1.3' apply false
 	//https://plugins.gradle.org/plugin/com.google.cloud.tools.jib
 	id 'com.google.cloud.tools.jib' version '3.3.2' apply false
 	//https://plugins.gradle.org/plugin/com.gorylenko.gradle-git-properties

--- a/frontend/build.gradle
+++ b/frontend/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.github.node-gradle.node" version "5.0.0"
+    id "com.github.node-gradle.node" version "7.0.0"
     id 'com.bmuschko.docker-remote-api' version '9.3.3'
 }
 

--- a/selenium-tests/build.gradle
+++ b/selenium-tests/build.gradle
@@ -7,7 +7,7 @@ sourceCompatibility = '17'
 
 dependencies {
     testImplementation 'org.seleniumhq.selenium:selenium-java:4.12.1'
-    testImplementation 'org.seleniumhq.selenium:selenium-grid:4.12.1'
+    testImplementation 'org.seleniumhq.selenium:selenium-grid:4.13.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
     testImplementation 'commons-io:commons-io:2.13.0'
 }


### PR DESCRIPTION
Updated the following dependencies:
- org.seleniumhq.selenium:selenium-grid from 4.12.1 to 4.13.0
- com.github.node-gradle.node from 5.0.0 to 7.0.0
- org.springframework.boot from 3.0.5 to 3.1.4
- io.spring.dependency-management from 1.1.0 to 1.1.3
- com.google.guava:guava from 31.1-jre to 32.1.2-jre