### PR TITLE
Fix NPE in DODCharacter.equals

### DIFF
--- a/backend/src/main/java/dk/dodgame/domain/character/model/DODCharacter.java
+++ b/backend/src/main/java/dk/dodgame/domain/character/model/DODCharacter.java
@@ -116,7 +116,7 @@ public class DODCharacter implements Serializable {
       return false;
     }
     DODCharacter that = (DODCharacter) o;
-    return id.equals(that.id) && Objects.equals(name, that.name);
+    return Objects.equals(id, that.id) && Objects.equals(name, that.name);
   }
 
   @Override


### PR DESCRIPTION
## Summary
- guard against null id in DODCharacter.equals

## Testing
- `gradle test --no-daemon --offline` *(fails: Plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842cc64508c833186252f5064daf650