### PR TITLE
fix(frontend): resolve npm vulnerabilities

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,6 +41,15 @@
     "typescript": "^4.8.4",
     "web-vitals": "^2.1.4"
   },
+  "overrides": {
+    "nth-check": "^2.1.1",
+    "postcss": "^8.5.6",
+    "webpack-dev-server": "^5.2.2",
+    "resolve-url-loader": "^5.0.0",
+    "svgo": "^2.8.0",
+    "@svgr/plugin-svgo": "^8.1.0",
+    "@svgr/webpack": "^8.1.0"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/frontend/src/services/axios/useLoadAppDataWithRetry.ts
+++ b/frontend/src/services/axios/useLoadAppDataWithRetry.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useAxios } from "./useAxios";
 import { showFatalConnectionErrorSnackbar, showNoConnectionWarningSnackbar } from "../../utils/DODSnackbars";
 import { operation, options } from "../../utils/DODRetryOptions";
-import { createTimeout } from "retry";
+import { createTimeout, CreateTimeoutOptions } from "retry";
 import { closeSnackbar, enqueueSnackbar } from "notistack";
 import { AxiosError } from "axios";
 
@@ -29,7 +29,10 @@ export const useLoadAppDataWithRetry = (appDataEndpoints: AppDataEndpoint[]) => 
         if (dataJSON === null) {
           try {
             operation.attempt(async (currentAttempt) => {
-              const currentTimeout = createTimeout(currentAttempt - 1, options);
+              const currentTimeout = createTimeout(
+                currentAttempt - 1,
+                options as CreateTimeoutOptions
+              );
 
               try {
                 for (const key in endpoint) {


### PR DESCRIPTION
## Summary
- add overrides in `package.json` to fix vulnerable dependencies
- adjust retry timeout invocation to satisfy new types

## Checklist
- [x] All unit/integration tests pass
- [x] Coverage ≥ 80 %


------
https://chatgpt.com/codex/tasks/task_e_686d10b04294833188223edb5df97744