### PR TITLE
Fix deprecated API usages

### DIFF
--- a/backend/src/main/java/dk/dodgame/domain/changerequest/model/ChangeKeyDeserializer.java
+++ b/backend/src/main/java/dk/dodgame/domain/changerequest/model/ChangeKeyDeserializer.java
@@ -70,7 +70,8 @@ public class ChangeKeyDeserializer extends JsonDeserializer<ChangeKey> {
       }
       throw new IllegalStateException("Unexpected Secondary ChangeType: " + secondaryChangeKey.getChangeType());
     }
-    throw new JsonParseException(jp, "Tried everything, but can't parse ChangeKey property: " + jp.currentName());
+    throw new JsonParseException(jp,
+        "Tried everything, but can't parse ChangeKey property: " + jp.getCurrentName());
   }
 }
 

--- a/backend/src/main/java/dk/dodgame/system/security/WebSecurityConfig.java
+++ b/backend/src/main/java/dk/dodgame/system/security/WebSecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -59,9 +60,10 @@ public class WebSecurityConfig {
   }
 
   private RequestMatcher requestMatcher(String httpMethod, String... patterns) {
+    HttpMethod method = HttpMethod.valueOf(httpMethod);
     return new OrRequestMatcher(Arrays
         .stream(patterns)
-        .map(pattern -> new AntPathRequestMatcher(pattern, httpMethod, false))
+        .map(pattern -> AntPathRequestMatcher.antMatcher(method, pattern))
         .collect(Collectors.toList()));
   }
 


### PR DESCRIPTION
## Summary
- replace deprecated `jp.currentName()` usage
- replace deprecated `AntPathRequestMatcher` constructor usage

## Testing
- `./gradlew :backend:compileJava --warning-mode all`
- `./gradlew test -x :selenium-tests:composeBuild -x :selenium-tests:test` *(fails: There were failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687e394ac9548331be3f701b8275a1e6